### PR TITLE
fix for deprecated originalKeywordKind

### DIFF
--- a/util/usage.ts
+++ b/util/usage.ts
@@ -21,6 +21,13 @@ interface InternalVariableInfo {
     uses: VariableUse[];
 }
 
+function identifierToKeywordKind(node) {
+    if (ts.idenifierToKeywordKind === undefined) {
+        return node.originalKeywordKind;
+    }
+    return ts.idenifierToKeywordKind(node);
+}
+
 export interface VariableInfo {
     domain: DeclarationDomain;
     exported: boolean;
@@ -56,7 +63,7 @@ export function getUsageDomain(node: ts.Identifier): UsageDomain | undefined {
     const parent = node.parent!;
     switch (parent.kind) {
         case ts.SyntaxKind.TypeReference:
-            return node.originalKeywordKind !== ts.SyntaxKind.ConstKeyword ? UsageDomain.Type : undefined;
+            return identifierToKeywordKind(node) !== ts.SyntaxKind.ConstKeyword ? UsageDomain.Type : undefined;
         case ts.SyntaxKind.ExpressionWithTypeArguments:
             return (<ts.HeritageClause>parent.parent).token === ts.SyntaxKind.ImplementsKeyword ||
                 parent.parent!.parent!.kind === ts.SyntaxKind.InterfaceDeclaration
@@ -147,7 +154,8 @@ export function getDeclarationDomain(node: ts.Identifier): DeclarationDomain | u
         case ts.SyntaxKind.ModuleDeclaration:
             return DeclarationDomain.Namespace;
         case ts.SyntaxKind.Parameter:
-            if (node.parent!.parent!.kind === ts.SyntaxKind.IndexSignature || node.originalKeywordKind === ts.SyntaxKind.ThisKeyword)
+            if (node.parent!.parent!.kind === ts.SyntaxKind.IndexSignature ||
+                identifierToKeywordKind(node) === ts.SyntaxKind.ThisKeyword)
                 return;
             // falls through
         case ts.SyntaxKind.BindingElement:
@@ -647,7 +655,7 @@ class UsageWalker {
                 case ts.SyntaxKind.Parameter:
                     if (node.parent!.kind !== ts.SyntaxKind.IndexSignature &&
                         ((<ts.ParameterDeclaration>node).name.kind !== ts.SyntaxKind.Identifier ||
-                         (<ts.Identifier>(<ts.NamedDeclaration>node).name).originalKeywordKind !== ts.SyntaxKind.ThisKeyword))
+                         identifierToKeywordKind(<ts.Identifier>(<ts.NamedDeclaration>node).name) !== ts.SyntaxKind.ThisKeyword))
                         this._handleBindingName(<ts.Identifier>(<ts.NamedDeclaration>node).name, false, false);
                     break;
                 case ts.SyntaxKind.EnumMember:

--- a/util/util.ts
+++ b/util/util.ts
@@ -9,6 +9,14 @@ import {
 import { isBigIntLiteral, isUniqueESSymbolType } from '../typeguard/3.2';
 import { isBooleanLiteralType, unionTypeParts, getPropertyNameFromType } from './type';
 
+
+function identifierToKeywordKind(node) {
+    if (ts.idenifierToKeywordKind === undefined) {
+        return node.originalKeywordKind;
+    }
+    return ts.idenifierToKeywordKind(node);
+}
+
 export function getChildOfKind<T extends ts.SyntaxKind>(node: ts.Node, kind: T, sourceFile?: ts.SourceFile) {
     for (const child of node.getChildren(sourceFile))
         if (child.kind === kind)
@@ -40,7 +48,7 @@ export function isKeywordKind(kind: ts.SyntaxKind) {
 }
 
 export function isThisParameter(parameter: ts.ParameterDeclaration): boolean {
-    return parameter.name.kind === ts.SyntaxKind.Identifier && parameter.name.originalKeywordKind === ts.SyntaxKind.ThisKeyword;
+    return parameter.name.kind === ts.SyntaxKind.Identifier && identifierToKeywordKind(parameter.name) === ts.SyntaxKind.ThisKeyword;
 }
 
 export function getModifier(node: ts.Node, kind: ts.Modifier['kind']): ts.Modifier | undefined {


### PR DESCRIPTION
As of TypeScript 5.0, `node.originalKeywordKind` is deprecated.

As of TypeScript 5.2, it has been removed.

This fix uses the suggested alternative, `idenifierToKeywordKind(node)` when available. So it should work with TypeScript 5 without sacrificing backwards compatibility. 